### PR TITLE
Fix insert statement for primo_schema.sql

### DIFF
--- a/primo_schema.sql
+++ b/primo_schema.sql
@@ -56,7 +56,7 @@ ALTER TABLE
 INSERT INTO
     public.config (id, value, options, created_at)
 VALUES
-    ('github_token', null, null, now(), now());
+    ('github_token', null, null, now());
 
 --
 -- Name: pages; Type: TABLE; Schema: public; Owner: postgres


### PR DESCRIPTION
There was an extra insert value for public.config table that stopped supabase from installing the database